### PR TITLE
Fix lock icon state logic and update unlock icon

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -902,7 +902,7 @@ export const UNAVAILABLE_STATES = ["unavailable", "unknown"];
 
 export const STATES_OFF = [
   "closed",
-  "locked",
+  "unlocked",
   "off",
   "docked",
   "idle",
@@ -1015,7 +1015,7 @@ export const DOMAIN_ICONS = {
   fan: { on: "mdi:fan", off: "mdi:fan-off" },
   climate: { on: "mdi:fan", off: "mdi:fan-off" },
   media_player: { on: "mdi:cast", off: "mdi:cast-off" },
-  lock: { on: "mdi:lock", off: "mdi:lock-open" },
+  lock: { on: "mdi:lock", off: "mdi:lock-open-variant" },
   vacuum: { on: "mdi:robot-vacuum", off: "mdi:robot-vacuum-off" },
   binary_sensor: {
     motion: "mdi:motion-sensor",


### PR DESCRIPTION
- Change STATES_OFF to use 'unlocked' instead of 'locked' so locked locks show as active state
- Update unlock icon from 'mdi:lock-open' to 'mdi:lock-open-variant' to match HA convention